### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-speech-dataset-toolkit"
+description = "Basic audio tools using torchaudio for ComfyUI. It is assumed to assist in the speech dataset creation for ASR, TTS, etc."
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["faster-whisper==1.0.1", "git+https://github.com/kale4eat/demucs@no-torch-install#egg=demucs", "# nue asr", "git+https://github.com/rinnakk/nue-asr", "# nemo-asr", "Cython", "git+https://github.com/reazon-research/ReazonSpeech#subdirectory=pkg/nemo-asr", "# kotoba-whisper", "transformers", "accelerate"]
+
+[project.urls]
+Repository = "https://github.com/kale4eat/ComfyUI-speech-dataset-toolkit"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-speech-dataset-toolkit"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!