### PR TITLE
Make AUDIO compatible with ComfyUI audio (with backwards compatibility for AudioData

### DIFF
--- a/ai/demucs_nodes.py
+++ b/ai/demucs_nodes.py
@@ -87,23 +87,24 @@ class DemucsApply:
     def run(
         self,
         model: demucs.api.Separator,
-        audio: AudioData,
+        audio: dict|AudioData,
     ) -> tuple[
-        AudioData,
-        AudioData,
-        AudioData,
-        AudioData,
+        dict,
+        dict,
+        dict,
+        dict,
     ]:
         # clone to avoid in-place error when different elements internally point to the same memory location
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         model_input_wave = convert_audio_channels(
-            audio.waveform.clone(), model.audio_channels
+            audioData.waveform.clone(), model.audio_channels
         ).clone()
-        _, separated = model.separate_tensor(model_input_wave, sr=audio.sample_rate)
+        _, separated = model.separate_tensor(model_input_wave, sr=audioData.sample_rate)
         return (
-            AudioData(separated["drums"], audio.sample_rate),
-            AudioData(separated["bass"], audio.sample_rate),
-            AudioData(separated["other"], audio.sample_rate),
-            AudioData(separated["vocals"], audio.sample_rate),
+            AudioData(separated["drums"], audioData.sample_rate).to_comfyUI_audio(),
+            AudioData(separated["bass"], audioData.sample_rate).to_comfyUI_audio(),
+            AudioData(separated["other"], audioData.sample_rate).to_comfyUI_audio(),
+            AudioData(separated["vocals"], audioData.sample_rate).to_comfyUI_audio(),
         )
 
 

--- a/ai/faster_whisper_nodes.py
+++ b/ai/faster_whisper_nodes.py
@@ -92,7 +92,7 @@ class FasterWhisperTranscribe:
     ):
         audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         model_input_wave = audioData.waveform.clone()
-        if audio.is_stereo():
+        if audioData.is_stereo():
             model_input_wave = model_input_wave.mean(dim=0, keepdim=True)
 
         WHISPER_SR = 16000

--- a/ai/faster_whisper_nodes.py
+++ b/ai/faster_whisper_nodes.py
@@ -84,23 +84,24 @@ class FasterWhisperTranscribe:
     def transcribe(
         self,
         model: WhisperModel,
-        audio: AudioData,
+        audio: AudioData|dict,
         beam_size: int,
         best_of: int,
         language: str = "",
         initial_prompt: str = "",
     ):
-        model_input_wave = audio.waveform.clone()
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        model_input_wave = audioData.waveform.clone()
         if audio.is_stereo():
             model_input_wave = model_input_wave.mean(dim=0, keepdim=True)
 
         WHISPER_SR = 16000
-        if audio.sample_rate != WHISPER_SR:
+        if audioData.sample_rate != WHISPER_SR:
             transform = torchaudio.transforms.Resample(
-                orig_freq=audio.sample_rate, new_freq=WHISPER_SR
+                orig_freq=audioData.sample_rate, new_freq=WHISPER_SR
             )
 
-            model_input_wave = transform(audio.waveform)
+            model_input_wave = transform(audioData.waveform)
 
         segments, _ = model.transcribe(
             model_input_wave[0].numpy(),

--- a/ai/kotoba_whisper_nodes.py
+++ b/ai/kotoba_whisper_nodes.py
@@ -179,11 +179,11 @@ class KotobaWhisperTranscribeLong:
         pipe = model
         audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         model_input_wave = audioData.waveform.clone()
-        if audio.is_stereo():
+        if audioData.is_stereo():
             model_input_wave = model_input_wave.mean(dim=0, keepdim=True)
 
         WHISPER_SR = 16000
-        if audio.sample_rate != WHISPER_SR:
+        if audioData.sample_rate != WHISPER_SR:
             transform = torchaudio.transforms.Resample(
                 orig_freq=audioData.sample_rate, new_freq=WHISPER_SR
             )

--- a/ai/kotoba_whisper_nodes.py
+++ b/ai/kotoba_whisper_nodes.py
@@ -116,21 +116,22 @@ class KotobaWhisperTranscribeShort:
     def transcribe(
         self,
         model: Pipeline,
-        audio: AudioData,
+        audio: AudioData|dict,
         prompt: str = "",
     ):
         pipe = model
-        model_input_wave = audio.waveform.clone()
-        if audio.is_stereo():
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        model_input_wave = audioData.waveform.clone()
+        if audioData.is_stereo():
             model_input_wave = model_input_wave.mean(dim=0, keepdim=True)
 
         WHISPER_SR = 16000
-        if audio.sample_rate != WHISPER_SR:
+        if audioData.sample_rate != WHISPER_SR:
             transform = torchaudio.transforms.Resample(
-                orig_freq=audio.sample_rate, new_freq=WHISPER_SR
+                orig_freq=audioData.sample_rate, new_freq=WHISPER_SR
             )
 
-            model_input_wave = transform(audio.waveform)
+            model_input_wave = transform(audioData.waveform)
 
         model_input_wave = model_input_wave.numpy()[0]
         generate_kwargs = {"language": "japanese", "task": "transcribe"}
@@ -173,20 +174,21 @@ class KotobaWhisperTranscribeLong:
     def transcribe(
         self,
         model: Pipeline,
-        audio: AudioData,
+        audio: AudioData|dict,
     ):
         pipe = model
-        model_input_wave = audio.waveform.clone()
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        model_input_wave = audioData.waveform.clone()
         if audio.is_stereo():
             model_input_wave = model_input_wave.mean(dim=0, keepdim=True)
 
         WHISPER_SR = 16000
         if audio.sample_rate != WHISPER_SR:
             transform = torchaudio.transforms.Resample(
-                orig_freq=audio.sample_rate, new_freq=WHISPER_SR
+                orig_freq=audioData.sample_rate, new_freq=WHISPER_SR
             )
 
-            model_input_wave = transform(audio.waveform)
+            model_input_wave = transform(audioData.waveform)
 
         model_input_wave = model_input_wave.numpy()[0]
         generate_kwargs = {"language": "japanese", "task": "transcribe"}

--- a/ai/nemo_asr_nodes.py
+++ b/ai/nemo_asr_nodes.py
@@ -56,9 +56,10 @@ class NemoAsrTranscribe:
     def transcribe(
         self,
         model,
-        audio: AudioData,
+        audio: AudioData|dict,
     ):
-        model_input_audio = audio_from_tensor(audio.waveform, audio.sample_rate)
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        model_input_audio = audio_from_tensor(audioData.waveform, audioData.sample_rate)
         result = transcribe(model, model_input_audio)
         return (
             result.text,

--- a/ai/nue_asr_nodes.py
+++ b/ai/nue_asr_nodes.py
@@ -52,7 +52,7 @@ class NueAsrTranscribe:
         audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         model, tokenizer = model
         NUA_ASR_SR = 16000
-        model_input_wave = audio.waveform
+        model_input_wave = audioData.waveform
         if audioData.sample_rate != NUA_ASR_SR:
             transform = torchaudio.transforms.Resample(
                 orig_freq=audioData.sample_rate, new_freq=NUA_ASR_SR

--- a/ai/nue_asr_nodes.py
+++ b/ai/nue_asr_nodes.py
@@ -48,13 +48,14 @@ class NueAsrTranscribe:
     RETURN_NAMES = ("text",)
     FUNCTION = "transcribe"
 
-    def transcribe(self, model, audio: AudioData):
+    def transcribe(self, model, audio: AudioData|dict):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         model, tokenizer = model
         NUA_ASR_SR = 16000
         model_input_wave = audio.waveform
-        if audio.sample_rate != NUA_ASR_SR:
+        if audioData.sample_rate != NUA_ASR_SR:
             transform = torchaudio.transforms.Resample(
-                orig_freq=audio.sample_rate, new_freq=NUA_ASR_SR
+                orig_freq=audioData.sample_rate, new_freq=NUA_ASR_SR
             )
 
             model_input_wave = transform(model_input_wave)

--- a/ai/speach_mos.py
+++ b/ai/speach_mos.py
@@ -53,12 +53,13 @@ class SpeechMOSScore:
     def score(
         self,
         model,
-        audio: AudioData,
+        audio: AudioData|dict,
     ):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         device = next(model.parameters()).device
-        model_input_wave = audio.waveform.clone().to(device)
+        model_input_wave = audioData.waveform.clone().to(device)
         with torch.no_grad():
-            score = model(model_input_wave, audio.sample_rate).item()
+            score = model(model_input_wave, audioData.sample_rate).item()
         del model_input_wave
         torch.cuda.empty_cache()
         return (score,)

--- a/edit_nodes.py
+++ b/edit_nodes.py
@@ -27,17 +27,18 @@ class CutAudio:
 
     def cut_audio(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         start_second: float,
         end_second: float,
     ):
-        start_sample = max(0, int(start_second * audio.sample_rate) - 1)
-        end_sample = max(0, int(end_second * audio.sample_rate) - 1)
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        start_sample = max(0, int(start_second * audioData.sample_rate) - 1)
+        end_sample = max(0, int(end_second * audioData.sample_rate) - 1)
         if start_sample == end_sample:
-            return (audio.waveform.detach().clone(),)
-        view1 = audio.waveform[..., :start_sample]
-        view2 = audio.waveform[..., end_sample:]
-        return AudioData(torch.concat([view1, view2], dim=-1), audio.sample_rate)
+            return (audioData.waveform.detach().clone(),)
+        view1 = audioData.waveform[..., :start_sample]
+        view2 = audioData.waveform[..., end_sample:]
+        return AudioData(torch.concat([view1, view2], dim=-1), audioData.sample_rate).to_comfyUI_audio()
 
 
 class TrimAudio:
@@ -59,16 +60,17 @@ class TrimAudio:
 
     def trim_audio(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         start_second: float,
         end_second: float,
     ):
-        start_sample = max(0, int(start_second * audio.sample_rate) - 1)
-        end_sample = max(0, int(end_second * audio.sample_rate) - 1)
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        start_sample = max(0, int(start_second * audioData.sample_rate) - 1)
+        end_sample = max(0, int(end_second * audioData.sample_rate) - 1)
         if start_sample == end_sample:
-            return (audio.waveform.detach().clone(),)
-        view = audio.waveform[..., start_sample:end_sample]
-        return (AudioData(view.detach().clone(), audio.sample_rate),)
+            return (audioData.waveform.detach().clone(),)
+        view = audioData.waveform[..., start_sample:end_sample]
+        return (AudioData(view.detach().clone(), audioData.sample_rate).to_comfyUI_audio(),)
 
 
 class TrimAudioBySample:
@@ -94,10 +96,11 @@ class TrimAudioBySample:
         start_sample: int,
         end_sample: int,
     ):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         if start_sample == end_sample:
-            return (audio.waveform.detach().clone(),)
-        view = audio.waveform[..., start_sample:end_sample]
-        return (AudioData(view.detach().clone(), audio.sample_rate),)
+            return (audioData.waveform.detach().clone(),)
+        view = audioData.waveform[..., start_sample:end_sample]
+        return (AudioData(view.detach().clone(), audioData.sample_rate).to_comfyUI_audio(),)
 
 
 class SilenceAudio:
@@ -119,17 +122,18 @@ class SilenceAudio:
 
     def silence_audio(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         start_second: float,
         end_second: float,
     ):
-        start_sample = max(0, int(start_second * audio.sample_rate) - 1)
-        end_sample = max(0, int(end_second * audio.sample_rate) - 1)
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        start_sample = max(0, int(start_second * audioData.sample_rate) - 1)
+        end_sample = max(0, int(end_second * audioData.sample_rate) - 1)
         if start_sample == end_sample:
-            return (audio.waveform.detach().clone(),)
-        copy_waveform = audio.waveform.detach().clone()
+            return (audioData.waveform.detach().clone(),)
+        copy_waveform = audioData.waveform.detach().clone()
         copy_waveform[:, start_sample:end_sample] = 0
-        return (AudioData(copy_waveform, audio.sample_rate),)
+        return (AudioData(copy_waveform, audioData.sample_rate).to_comfyUI_audio(),)
 
 
 class MakeSilenceAudio:
@@ -158,7 +162,7 @@ class MakeSilenceAudio:
         ch_dim = 1 if channel == "monoral" else 2
         samples = int(second * sample_rate)
         wave = torch.zeros((ch_dim, samples))
-        return (AudioData(wave, sample_rate),)
+        return (AudioData(wave, sample_rate).to_comfyUI_audio(),)
 
 
 class SplitAudio:
@@ -177,12 +181,13 @@ class SplitAudio:
     RETURN_NAMES = ("audio",)
     FUNCTION = "split_audio"
 
-    def split_audio(self, audio: AudioData, second: float):
-        sample = max(0, int(second * audio.sample_rate) - 1)
-        view1 = audio.waveform[..., :sample]
-        view2 = audio.waveform[..., sample:]
-        audio1 = AudioData(view1.detach().clone(), audio.sample_rate)
-        audio2 = AudioData(view2.detach().clone(), audio.sample_rate)
+    def split_audio(self, audio: AudioData|dict, second: float):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        sample = max(0, int(second * audioData.sample_rate) - 1)
+        view1 = audioData.waveform[..., :sample]
+        view2 = audioData.waveform[..., sample:]
+        audio1 = AudioData(view1.detach().clone(), audioData.sample_rate).to_comfyUI_audio()
+        audio2 = AudioData(view2.detach().clone(), audioData.sample_rate).to_comfyUI_audio()
         return (audio1, audio2)
 
 
@@ -203,23 +208,25 @@ class ConcatAudio:
     RETURN_NAMES = ("audio",)
     FUNCTION = "join_audio"
 
-    def join_audio(self, audio1: AudioData, audio2: AudioData, silent_interval: float):
-        if audio1.sample_rate != audio2.sample_rate:
+    def join_audio(self, audio1: AudioData|dict, audio2: AudioData|dict, silent_interval: float):
+        audioData1 = AudioData.from_comfyUI_audio(audio1) if isinstance(audio1,dict) else audio1
+        audioData2 = AudioData.from_comfyUI_audio(audio2) if isinstance(audio2,dict) else audio2
+        if audioData1.sample_rate != audio2.sample_rate:
             raise ValueError(
                 f"sample_rate is different\naudio1: {audio1.sample_rate}\naudio2: {audio2.sample_rate}"
             )
-        if not audio1.is_stereo() == audio2.is_stereo():
-            audio1_ch = "stereo" if audio1.is_stereo() else "monoral"
-            audio2_ch = "stereo" if audio1.is_stereo() else "monoral"
+        if not audioData1.is_stereo() == audioData2.is_stereo():
+            audio1_ch = "stereo" if audioData1.is_stereo() else "monoral"
+            audio2_ch = "stereo" if audioData1.is_stereo() else "monoral"
             raise ValueError(f"naudio1 is {audio1_ch} but audio2 is {audio2_ch}")
 
-        samples = int(silent_interval * audio1.sample_rate)
-        ch_dim = 2 if audio1.is_stereo() else 1
+        samples = int(silent_interval * audioData1.sample_rate)
+        ch_dim = 2 if audioData1.is_stereo() else 1
         interval = torch.zeros((ch_dim, samples))
         new_waveform = torch.concat(
-            [audio1.waveform, interval, audio2.waveform], dim=-1
+            [audioData1.waveform, interval, audioData2.waveform], dim=-1
         )
-        return (AudioData(new_waveform, audio1.sample_rate),)
+        return (AudioData(new_waveform, audio1.sample_rate).to_comfyUI_audio(),)
 
 
 class JoinAudio:
@@ -238,26 +245,28 @@ class JoinAudio:
     RETURN_NAMES = ("audio",)
     FUNCTION = "join_audio"
 
-    def join_audio(self, audios: list[AudioData], silent_interval: float):
-        if len(audios) == 0:
+    def join_audio(self, audios: list[AudioData|dict], silent_interval: float):
+        audioDatas = map(lambda audio: AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio, audios)
+
+        if len(audioDatas) == 0:
             raise ValueError("Audios size is zero.")
-        if not all([audio.sample_rate == audios[0].sample_rate for audio in audios]):
+        if not all([audio.sample_rate == audioDatas[0].sample_rate for audio in audioDatas]):
             raise ValueError("Sample rates must be the same.")
-        if not all([audio.is_stereo() == audios[0].is_stereo() for audio in audios]):
+        if not all([audio.is_stereo() == audioDatas[0].is_stereo() for audio in audioDatas]):
             raise ValueError("All auido must be either stereo or monoral.")
 
-        samples = int(silent_interval * audios[0].sample_rate)
-        ch_dim = 2 if audios[0].is_stereo() else 1
+        samples = int(silent_interval * audioDatas[0].sample_rate)
+        ch_dim = 2 if audioDatas[0].is_stereo() else 1
         interval = torch.zeros((ch_dim, samples))
         new_tensors = []
-        for audio in audios:
+        for audio in audioDatas:
             new_tensors.append(audio)
             new_tensors.append(interval)
 
         new_tensors.pop()
 
         new_waveforms = torch.concat(new_tensors, dim=-1)
-        return (AudioData(new_waveforms, audios[0].sample_rate),)
+        return (AudioData(new_waveforms, audioDatas[0].sample_rate).to_comfyUI_audio(),)
 
 
 class ResampleAudio:
@@ -301,22 +310,23 @@ class ResampleAudio:
 
     def resample(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         new_freq: int,
         resampling_method: str,
         lowpass_filter_width: int,
         rolloff: float,
         beta=None,
     ):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         transform = torchaudio.transforms.Resample(
-            orig_freq=audio.sample_rate,
+            orig_freq=audioData.sample_rate,
             new_freq=new_freq,
             resampling_method=resampling_method,
             lowpass_filter_width=lowpass_filter_width,
             rolloff=rolloff,
             beta=beta,
         )
-        return (AudioData(transform(audio.waveform), new_freq),)
+        return (AudioData(transform(audioData.waveform), new_freq).to_comfyUI_audio(),)
 
 
 NODE_CLASS_MAPPINGS = {

--- a/filter_nodes.py
+++ b/filter_nodes.py
@@ -30,8 +30,9 @@ class HighpassBiquad:
     RETURN_NAMES = ("audio",)
     FUNCTION = "highpass_biquad"
 
-    def highpass_biquad(self, audio: AudioData, cutoff_freq: float, Q: float):
-        waveform = F.highpass_biquad(audio.waveform, audio.sample_rate, cutoff_freq, Q)
+    def highpass_biquad(self, audio: AudioData|dict, cutoff_freq: float, Q: float):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        waveform = F.highpass_biquad(audioData.waveform, audioData.sample_rate, cutoff_freq, Q)
         return (waveform,)
 
 
@@ -56,5 +57,6 @@ class LowpassBiquad:
     FUNCTION = "lowpass_biquad"
 
     def lowpass_biquad(self, audio: AudioData, cutoff_freq: float, Q: float):
-        waveform = F.lowpass_biquad(audio.waveform, audio.sample_rate, cutoff_freq, Q)
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        waveform = F.lowpass_biquad(audioData.waveform, audioData.sample_rate, cutoff_freq, Q)
         return (waveform,)

--- a/node_def.py
+++ b/node_def.py
@@ -21,8 +21,15 @@ class AudioData:
 
     sample_rate: int
 
+    @staticmethod
+    def from_comfyUI_audio(dic:dict):
+        return AudioData(dic["waveform"].squeeze(0), dic["sample_rate"])
+
     def is_stereo(self):
         return self.waveform.size(0) > 1
+    
+    def to_comfyUI_audio(self):
+        return { "waveform": self.waveform.unsqueeze(0), "sample_rate": self.sample_rate }
 
 
 @dataclass(frozen=True)

--- a/spec_nodes.py
+++ b/spec_nodes.py
@@ -25,7 +25,8 @@ class Spectrogram:
     RETURN_NAMES = ("spec",)
     FUNCTION = "spectrogram"
 
-    def spectrogram(self, audio: AudioData, n_fft, win_length=None, hop_length=None):
+    def spectrogram(self, audio: AudioData|dict, n_fft, win_length=None, hop_length=None):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         spectrogram = T.Spectrogram(
             n_fft=n_fft,
             win_length=win_length if win_length != -1 else None,
@@ -34,7 +35,7 @@ class Spectrogram:
             pad_mode="reflect",
             power=2.0,
         )
-        spec = SpectrogramData(spectrogram(audio.waveform), audio.sample_rate)
+        spec = SpectrogramData(spectrogram(audioData.waveform), audioData.sample_rate)
         return (spec,)
 
 
@@ -67,7 +68,7 @@ class GriffinLim:
             hop_length=hop_length if hop_length != -1 else None,
         )
         waveform = griffin_lim(spec.waveform)
-        return (AudioData(waveform, spec.sample_rate),)
+        return (AudioData(waveform, spec.sample_rate).to_comfyUI_audio(),)
 
 
 class MelSpectrogram:
@@ -93,14 +94,15 @@ class MelSpectrogram:
 
     def mel_spectrogram(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         n_fft,
         n_mels,
         win_length=None,
         hop_length=None,
     ):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         mel_spectrogram = T.MelSpectrogram(
-            sample_rate=audio.sample_rate,
+            sample_rate=audioData.sample_rate,
             n_fft=n_fft,
             win_length=win_length if win_length != -1 else None,
             hop_length=hop_length if hop_length != -1 else None,
@@ -113,8 +115,8 @@ class MelSpectrogram:
             mel_scale="htk",
         )
 
-        melspec = mel_spectrogram(audio.waveform)
-        return (SpectrogramData(melspec, audio.sample_rate),)
+        melspec = mel_spectrogram(audioData.waveform)
+        return (SpectrogramData(melspec, audioData.sample_rate),)
 
 
 class MFCC:
@@ -141,15 +143,16 @@ class MFCC:
 
     def MFCC(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         n_mfcc,
         n_fft,
         n_mels,
         win_length=None,
         hop_length=None,
     ):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         mfcc_transform = T.MFCC(
-            sample_rate=audio.sample_rate,
+            sample_rate=audioData.sample_rate,
             n_mfcc=n_mfcc,
             melkwargs={
                 "n_fft": n_fft,
@@ -160,7 +163,7 @@ class MFCC:
             },
         )
 
-        mfcc = mfcc_transform(audio.waveform)
+        mfcc = mfcc_transform(audioData.waveform)
         return (mfcc,)
 
 
@@ -188,15 +191,16 @@ class LFCC:
 
     def LFCC(
         self,
-        audio: AudioData,
+        audio: AudioData|dict,
         n_filter,
         n_lfcc,
         n_fft,
         win_length=None,
         hop_length=None,
     ):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         mfcc_transform = T.LFCC(
-            sample_rate=audio.sample_rate,
+            sample_rate=audioData.sample_rate,
             n_filter=n_filter,
             n_lfcc=n_lfcc,
             speckwargs={
@@ -206,7 +210,7 @@ class LFCC:
             },
         )
 
-        lfcc = mfcc_transform(audio.waveform)
+        lfcc = mfcc_transform(audioData.waveform)
         return (lfcc,)
 
 

--- a/visualize_node.py
+++ b/visualize_node.py
@@ -34,12 +34,13 @@ class PlotWaveForm:
     RETURN_NAMES = ("graph_image",)
     FUNCTION = "plot_waveform"
 
-    def plot_waveform(self, audio: AudioData, title: str):
+    def plot_waveform(self, audio: AudioData|dict, title: str):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         # refer: https://pytorch.org/tutorials/beginner/audio_preprocessing_tutorial.html
-        waveform = audio.waveform.numpy()
+        waveform = audioData.waveform.numpy()
 
         num_channels, num_frames = waveform.shape
-        time_axis = torch.arange(0, num_frames) / audio.sample_rate
+        time_axis = torch.arange(0, num_frames) / audioData.sample_rate
 
         figure, axes = plt.subplots(num_channels, 1)
         if num_channels == 1:
@@ -80,18 +81,19 @@ class PlotSpecgram:
     RETURN_NAMES = ("graph_image",)
     FUNCTION = "plot_specgram"
 
-    def plot_specgram(self, audio: AudioData, title: str):
+    def plot_specgram(self, audio: AudioData|dict, title: str):
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
         # refer: https://pytorch.org/tutorials/beginner/audio_preprocessing_tutorial.html
-        waveform = audio.waveform.numpy()
+        waveform = audioData.waveform.numpy()
 
         num_channels, num_frames = waveform.shape
-        time_axis = torch.arange(0, num_frames) / audio.sample_rate
+        time_axis = torch.arange(0, num_frames) / audioData.sample_rate
 
         figure, axes = plt.subplots(num_channels, 1)
         if num_channels == 1:
             axes = [axes]
         for c in range(num_channels):
-            axes[c].specgram(waveform[c], Fs=audio.sample_rate)
+            axes[c].specgram(waveform[c], Fs=audioData.sample_rate)
         figure.suptitle(title)
 
         # Create an in-memory buffer to store the image
@@ -205,14 +207,15 @@ class PlotPitch:
     FUNCTION = "plot_pitch"
 
     def plot_pitch(self, audio: AudioData):
-        pitch = F.detect_pitch_frequency(audio.waveform, audio.sample_rate)
+        audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio
+        pitch = F.detect_pitch_frequency(audioData.waveform, audioData.sample_rate)
         figure, axis = plt.subplots(1, 1)
         axis.set_title("Pitch Feature")
         axis.grid(True)
 
-        end_time = audio.waveform.shape[1] / audio.sample_rate
-        time_axis = torch.linspace(0, end_time, audio.waveform.shape[1])
-        axis.plot(time_axis, audio.waveform[0], linewidth=1, color="gray", alpha=0.3)
+        end_time = audioData.waveform.shape[1] / audioData.sample_rate
+        time_axis = torch.linspace(0, end_time, audioData.waveform.shape[1])
+        axis.plot(time_axis, audioData.waveform[0], linewidth=1, color="gray", alpha=0.3)
 
         axis2 = axis.twinx()
         time_axis = torch.linspace(0, end_time, pitch.shape[1])


### PR DESCRIPTION
Basically check for dict and convert it to AudioData, then proceed as normal and return a conversion back to dict everywhere. This makes it compatible with other ComfyUI Audio nodes

`audioData = AudioData.from_comfyUI_audio(audio) if isinstance(audio,dict) else audio`

And 

`AudtioData.to_comfyUI_audio()`

are used. Makes it easy to change if comfyUI ever decides to change its format again.

